### PR TITLE
Add arbiter example specs and update documentation

### DIFF
--- a/Dockerfile.boomslang
+++ b/Dockerfile.boomslang
@@ -7,6 +7,8 @@ RUN apt-get update && \
     apt-get install -y wget cmake autoconf time python3-dev python3-pip \
         meson ninja-build pkg-config swig \
         automake libtool libltdl-dev bison flex git \
+        graphviz \
+        pandoc texlive-xetex texlive-fonts-recommended texlive-plain-generic \
     && rm -rf /var/lib/apt/lists/*
 
 # Bookworm's meson may be too old for this project's C++23 features.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ REALIZABLE
 ```
 
 The wrapper also accepts TLSF specs piped on stdin (translated to LTL via
-the bundled `syfco`):
+the bundled `syfco`). The image ships example specs in `examples/`:
 ```
-$ cat spec.tlsf | ./scripts/acacia-bonsai.sh best_decomp_mona --tlsf
+$ cat examples/realizable.tlsf | ./scripts/acacia-bonsai.sh best_decomp_mona --tlsf
+REALIZABLE
+$ cat examples/unrealizable.tlsf | ./scripts/acacia-bonsai.sh best_decomp_mona --tlsf
+UNREALIZABLE
 ```
 
 When you exit the shell the container stops but is preserved. To re-enter
@@ -91,7 +94,7 @@ From outside the container you can also pipe a TLSF spec into the running
 (or stopped-then-started) container via `docker exec` / `docker start`:
 ```
 $ docker start acacia   # if it is stopped
-$ cat spec.tlsf | docker exec -i acacia \
+$ cat examples/realizable.tlsf | docker exec -i acacia \
       /opt/acacia-bonsai/scripts/acacia-bonsai.sh best_decomp_mona --tlsf
 ```
 
@@ -100,7 +103,7 @@ when the spec is realizable, use `acacia-synthesis.sh`. It accepts the same
 options as `acacia-bonsai.sh`; the REALIZABLE/UNREALIZABLE verdict goes to
 stderr so stdout carries only the AAG:
 ```
-$ cat spec.tlsf | docker exec -i acacia \
+$ cat examples/realizable.tlsf | docker exec -i acacia \
       /opt/acacia-bonsai/scripts/acacia-synthesis.sh \
       best_decomp_mona --tlsf > controller.aag
 ```
@@ -123,7 +126,7 @@ have Spot and the acacia-bonsai configurations built in — `--rm` is fine
 here because there is nothing left to compile:
 ```
 $ docker run --rm -it ghcr.io/gaperez64/acacia-bonsai:compiled
-$ cat spec.tlsf | docker run --rm -i \
+$ cat examples/realizable.tlsf | docker run --rm -i \
       ghcr.io/gaperez64/acacia-bonsai:compiled \
       /opt/acacia-bonsai/scripts/acacia-bonsai.sh best_decomp_mona --tlsf
 ```

--- a/examples/realizable.tlsf
+++ b/examples/realizable.tlsf
@@ -1,0 +1,72 @@
+INFO {
+  TITLE:       "Full Arbiter"
+  DESCRIPTION: "Parameterized Arbiter, where no spurious grants are allowed"
+  SEMANTICS:   Mealy
+  TARGET:      Mealy
+}
+
+GLOBAL {
+  PARAMETERS {
+    n = 3;
+  }
+
+  DEFINITIONS {
+    // ensures mutual exclusion on an n-ary bus
+    mutual_exclusion(bus) =
+     mone(bus,0,(SIZEOF bus) - 1);
+
+    // ensures that none of the signals
+    // bus[i] - bus[j] is HIGH
+    none(bus,i,j) =
+      &&[i <= t <= j]
+        !bus[t];
+
+    // ensures that at most one of the signals
+    // bus[i] - bus[j] is HIGH
+    mone(bus,i,j) =
+    i > j : false
+    i == j : true
+    i < j :
+      // either no signal of the lower half is HIGH and at
+      // most one signal of the upper half is HIGH
+      (none(bus, i, m(i,j)) && mone(bus, m(i,j) + 1, j)) ||
+      // or at most one signal of the lower half is HIGH
+      // and no signal in of the upper half is HIGH
+      (mone(bus, i, m(i,j)) && none(bus, m(i,j) + 1, j));
+
+    // returns the position between i and j
+    m(i,j) = (i + j) / 2;
+  }
+}
+
+MAIN {
+
+  INPUTS {
+    r[n]; // request signals
+  }
+
+  OUTPUTS {
+    g[n]; // grant signals
+  }
+
+  INVARIANTS {
+    // no spurious grants
+    &&[0 <= i < n] (
+      (g[i] && G !r[i] -> F !g[i]) &&
+      (g[i] && X (!r[i] && !g[i]) -> X (r[i] R !g[i]))
+    );
+
+    // ensure mutual exclusion on the output bus
+    mutual_exclusion(g);
+  }
+
+  GUARANTEES {
+    &&[0 <= i < n] (
+      // no grant before any request
+      (r[i] R !g[i]) &&
+      // every request is eventually granted
+      G (r[i] -> F g[i])
+    );
+  }
+
+}

--- a/examples/unrealizable.tlsf
+++ b/examples/unrealizable.tlsf
@@ -1,0 +1,79 @@
+INFO {
+  TITLE:       "Full Arbiter, unrealizable variant 1"
+  DESCRIPTION: "Parameterized Arbiter, where no spurious grants are allowed"
+  SEMANTICS:   Moore
+  TARGET:      Mealy
+}
+
+GLOBAL {
+  PARAMETERS {
+    n = 3;
+    u = 1;
+  }
+
+  DEFINITIONS {
+    // ensures mutual exclusion on an n-ary bus
+    mutual_exclusion(bus) =
+     mone(bus,0,(SIZEOF bus) - 1);
+
+    // ensures that none of the signals
+    // bus[i] - bus[j] is HIGH
+    none(bus,i,j) =
+      &&[i <= t <= j]
+        !bus[t];
+
+    // ensures that at most one of the signals
+    // bus[i] - bus[j] is HIGH
+    mone(bus,i,j) =
+    i > j : false
+    i == j : true
+    i < j :
+      // either no signal of the lower half is HIGH and at
+      // most one signal of the upper half is HIGH
+      (none(bus, i, m(i,j)) && mone(bus, m(i,j) + 1, j)) ||
+      // or at most one signal of the lower half is HIGH
+      // and no signal in of the upper half is HIGH
+      (mone(bus, i, m(i,j)) && none(bus, m(i,j) + 1, j));
+
+    // returns the position between i and j
+    m(i,j) = (i + j) / 2;
+  }
+}
+
+MAIN {
+
+  INPUTS {
+    r[n]; // request signals
+  }
+
+  OUTPUTS {
+    g[n]; // grant signals
+  }
+
+  INVARIANTS {
+    // no spurious grants
+    &&[0 <= i < n] (
+      (g[i] && G !r[i] -> F !g[i]) &&
+      (g[i] && X (!r[i] && !g[i]) -> X (r[i] R !g[i]))
+    );
+
+    // ensure mutual exclusion on the output bus
+    mutual_exclusion(g);
+
+    /* Making the benchmark unrealizable: ask for two grants at the same time,
+     * after u steps.
+     */
+    &&[0 <= i <n] ( &&[i < j < n] (r[i] && X r[j] ->
+      X[u] (g[i] && g[j])) );
+  }
+
+  GUARANTEES {
+    &&[0 <= i < n] (
+      // no grant before any request
+      (r[i] R !g[i]) &&
+      // every request is eventually granted
+      G (r[i] -> F g[i])
+    );
+  }
+
+}


### PR DESCRIPTION
## Summary
This PR adds example TLSF specifications for an arbiter problem and updates the documentation to reference these examples. It also adds additional build dependencies for documentation generation.

## Key Changes
- **Added two example arbiter specifications:**
  - `examples/realizable.tlsf`: A realizable parameterized arbiter specification with mutual exclusion constraints and no spurious grants
  - `examples/unrealizable.tlsf`: An unrealizable variant that adds an impossible constraint requiring two simultaneous grants after u steps
  
- **Updated README.md:**
  - Changed documentation examples to use the new `examples/realizable.tlsf` and `examples/unrealizable.tlsf` specs instead of generic `spec.tlsf`
  - Added note that example specs are shipped in the `examples/` directory
  - Updated all three code examples (stdin piping, docker exec, and docker run) to reference the concrete example files
  
- **Updated Dockerfile.boomslang:**
  - Added `graphviz` package for diagram generation
  - Added `pandoc`, `texlive-xetex`, `texlive-fonts-recommended`, and `texlive-plain-generic` packages for documentation processing

## Implementation Details
The arbiter examples demonstrate both realizable and unrealizable synthesis problems using parameterized specifications. The realizable version enforces mutual exclusion and prevents spurious grants, while the unrealizable version adds an impossible constraint that makes the specification unsatisfiable. These serve as concrete test cases for the acacia-bonsai tool.

https://claude.ai/code/session_01BZfXNxaKY7FbPbhWLRnHKH