### PR TITLE
fix(#91): add inkscape to boomslang image for PDF export of SVG plots

### DIFF
--- a/Dockerfile.boomslang
+++ b/Dockerfile.boomslang
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y wget cmake autoconf time python3-dev python3-pip \
         meson ninja-build pkg-config swig \
         automake libtool libltdl-dev bison flex git \
-        graphviz \
+        graphviz inkscape \
         pandoc texlive-xetex texlive-fonts-recommended texlive-plain-generic \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
nbconvert needs inkscape to rasterize SVG images (e.g. automaton diagrams rendered by Spot) when exporting a notebook to PDF.

https://claude.ai/code/session_01BZfXNxaKY7FbPbhWLRnHKH