### PR TITLE
fix: use /sbin/ldconfig in wheels-before-all.sh

### DIFF
--- a/.github/workflows/wheels-before-all.sh
+++ b/.github/workflows/wheels-before-all.sh
@@ -44,7 +44,7 @@ make -j"$(nproc)"
 make install
 
 echo "/opt/spot_install/lib" > /etc/ld.so.conf.d/spot.conf
-ldconfig
+/sbin/ldconfig
 
 echo "== Spot installed =="
 pkg-config --modversion libspot


### PR DESCRIPTION
Bare `ldconfig` fails in the manylinux_2_28 container because /sbin is not in the default PATH for the BEFORE_ALL hook. Use the absolute path so the dynamic-linker cache is updated regardless of PATH.

https://claude.ai/code/session_01MWmzFnm1egTJGhyT9Rn25U