### PR TITLE
fix: prepend gcc-toolset-14 to \$PATH instead of replacing it

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,7 @@ jobs:
             LD_LIBRARY_PATH=/opt/spot_install/lib
             CC=/opt/rh/gcc-toolset-14/root/usr/bin/gcc
             CXX=/opt/rh/gcc-toolset-14/root/usr/bin/g++
-            PATH=/opt/rh/gcc-toolset-14/root/usr/bin:/usr/local/bin:/usr/bin:/bin
+            PATH=/opt/rh/gcc-toolset-14/root/usr/bin:$PATH
           # auditwheel needs to see libspot.so.* at repair time to vendor
           # them into the wheel. Default search path in the container
           # doesn't include /opt/spot_install/lib.


### PR DESCRIPTION
The hardcoded PATH in CIBW_ENVIRONMENT_LINUX was dropping cibuildwheel's managed Python directory, causing "which: no python" failures during the wheel build. Prepending to $PATH keeps GCC 14 first while preserving whatever cibuildwheel injects (including the active CPython interpreter).

https://claude.ai/code/session_01MWmzFnm1egTJGhyT9Rn25U