### PR TITLE
fix: embed GCC runtime statically in macOS wheel to fix SIGABRT on im…

### DIFF
--- a/.github/workflows/wheels-before-all-macos.sh
+++ b/.github/workflows/wheels-before-all-macos.sh
@@ -32,6 +32,11 @@ wget -q "http://www.lrde.epita.fr/dload/spot/spot-${SPOT_VERSION}.tar.gz"
 tar -xzf "spot-${SPOT_VERSION}.tar.gz"
 cd "spot-${SPOT_VERSION}"
 
+# -static-libstdc++ / -static-libgcc embed the GCC runtime into libspot.dylib
+# and libbddx.dylib so the wheel has no dynamic dependency on GCC's
+# libstdc++.6.dylib or libgcc_s.1.1.dylib, which delocate may not follow
+# through @rpath chains correctly.
+LDFLAGS="-static-libstdc++ -static-libgcc" \
 ./configure \
     --prefix=/opt/spot_install \
     --enable-max-accsets=64 \

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,6 +78,7 @@ jobs:
             CXX=/opt/homebrew/bin/g++-14
             PATH=/opt/homebrew/bin:$PATH
             MACOSX_DEPLOYMENT_TARGET=15.0
+            LDFLAGS="-static-libstdc++ -static-libgcc"
           # delocate finds libspot.dylib via the LC_LOAD_DYLIB path embedded
           # at link time; DYLD_LIBRARY_PATH helps it resolve transitive deps.
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
…port

libspot.dylib links to GCC's libstdc++.6.dylib → libgcc_s.1.1.dylib. delocate resolves @rpath dependencies from LC_RPATH entries in each library, but may miss the libgcc_s chain, leaving the installed wheel with an unresolvable @rpath reference that causes dyld to SIGABRT on import.

Fix: pass -static-libstdc++ -static-libgcc when building both Spot (wheels-before-all-macos.sh) and the extension module (CIBW_ENVIRONMENT_MACOS). This embeds the GCC C++ and compiler runtimes directly into libspot.dylib and the extension, so the wheel only needs to bundle Spot's own libraries and has no external GCC runtime dependency.

Also add "Operating System :: MacOS :: MacOS X" classifier to pyproject.toml now that a macOS wheel is published.

https://claude.ai/code/session_01MWmzFnm1egTJGhyT9Rn25U