### PR TITLE
Fix TLSF to LTL translation for long formulas via file passing

### DIFF
--- a/scripts/acacia-bonsai.sh
+++ b/scripts/acacia-bonsai.sh
@@ -86,13 +86,16 @@ if [ "$USE_TLSF" = true ]; then
 
     PART=$(mktemp)
     SPEC=$(mktemp)
-    trap 'rm -f "$PART" "$SPEC"' EXIT
+    LTL=$(mktemp)
+    trap 'rm -f "$PART" "$SPEC" "$LTL"' EXIT
 
     # syfco wants a file path; slurp stdin into a temp file so we can also
     # extract the input/output partition with -pf.
     cat > "$SPEC"
 
-    LTL=$("$SYFCO" "$SPEC" -f ltlxba -m fully -pf "$PART") || {
+    # Write the LTL to a file and pass it via -F: some TLSF specs translate
+    # to formulas too long to fit on a command line.
+    "$SYFCO" "$SPEC" -f ltlxba -m fully -pf "$PART" > "$LTL" || {
         echo "Error: syfco failed to translate the TLSF input from stdin" >&2
         exit 4
     }
@@ -109,7 +112,7 @@ if [ "$USE_TLSF" = true ]; then
         esac
     done < "$PART"
 
-    exec "$BINARY" "${PASS_ARGS[@]}" -f "$LTL" -i "$ins" -o "$outs"
+    exec "$BINARY" "${PASS_ARGS[@]}" -F "$LTL" -i "$ins" -o "$outs"
 fi
 
 exec "$BINARY" "${PASS_ARGS[@]}"


### PR DESCRIPTION
## Summary
Modified the TLSF to LTL translation pipeline to pass formulas via a temporary file instead of command-line arguments, preventing issues with excessively long formulas that exceed command-line length limits.

## Key Changes
- Create a temporary file (`LTL`) to store the syfco-generated LTL formula instead of capturing it as a variable
- Update the syfco invocation to write output to the temporary file (`> "$LTL"`) rather than capturing to a variable
- Change the binary invocation to use the `-F` flag (file input) instead of `-f` flag (inline input), passing the temporary file path
- Update the EXIT trap to clean up the new `LTL` temporary file

## Implementation Details
This change addresses a limitation where TLSF specifications that translate to very long LTL formulas would fail because the formula string couldn't fit on the command line. By writing the formula to a file and using the `-F` flag to pass the file path instead, the solution supports arbitrarily long formulas while maintaining the same functionality.

https://claude.ai/code/session_01HnGsRRAMt3hnPgfsADR1iH